### PR TITLE
Update account-recovery.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/account-recovery.yml
+++ b/.github/ISSUE_TEMPLATE/account-recovery.yml
@@ -47,7 +47,7 @@ body:
     description: |
       By their nature account recovery issues are labor intensive. The PyPI team has limited resources available for their completion.
 
-      There may be a delay of few months or more between responses for these issues.
+      There may be an extended delay between responses for these issues.
     options:
     - label: I understand that it may take a significant amount of time to process my account recovery request.
       required: true

--- a/.github/ISSUE_TEMPLATE/account-recovery.yml
+++ b/.github/ISSUE_TEMPLATE/account-recovery.yml
@@ -25,6 +25,7 @@ body:
       State the reason for your request
       - Lost access to email address
       - Lost 2FA authentication app or security token
+      - Lost recovery codes 
   validations:
     required: true
 
@@ -46,8 +47,15 @@ body:
     description: |
       By their nature account recovery issues are labor intensive. The PyPI team has limited resources available for their completion.
 
-      There may be a delay of a week or more between responses for these issues.
+      There may be a delay of few months or more between responses for these issues.
     options:
     - label: I understand that it may take a significant amount of time to process my account recovery request.
       required: true
+      
+- type: checkboxes
+  attributes:
+    label: Recovery code lost
+    options:
+    - label: I have lost my 2FA authentication app or security token, and my recovery code as well
+      required: false
 ...


### PR DESCRIPTION
1. changed the delay to reflect the current reality
2. add a check box to tell the admin if the user has lost the recovery codes as well to avoid one extra round trip

For 2. here's an example of where this applies: https://github.com/pypi/support/issues/3200

Before the change:

1. User: I lost my 2FA access
2. Admin: I see valid recovery codes in the DB, have you tried them?
3. User: I lost them as well or never downloaded them
4. Admin: ok let me proceed with the reset process

After the change:

1. User: I lost my 2FA access, and the recovery codes as well
2. Admin: yes, I see valid recovery codes in the DB, ok let me proceed with the reset process

Why it matters? Because there can be months between two answers from the admin, so the change will spare those extra months.

