### PR TITLE
📝 Integrate Status Page mentions to issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/access-issues.yml
+++ b/.github/ISSUE_TEMPLATE/access-issues.yml
@@ -7,14 +7,29 @@ body:
 - type: markdown
   attributes:
     value: |
-      ⚠
-      This issue should be for problems accessing PyPI itself, including:
-      * pypi.org
-      * test.pypi.org
-      * files.pythonhosted.org
-  
-      This issue **should NOT** be for any non-PyPI properties (like
-      python.org, docs.python.org, etc.)
+      > [!CAUTION]
+      > Before using this form to report a new issue, please verify that it has
+      > not already been documented on the [Python Infrastructure Status Page].
+      > Remember to scroll to the *Past Incidents* to see if there is something
+      > that's just been addressed too.
+      >
+      > Verify first that your issue is not [already reported on GitHub][issue
+      > search].
+
+      > [!WARNING]
+      > This issue should be for problems accessing PyPI itself, including:
+      > * pypi.org
+      > * test.pypi.org
+      > * files.pythonhosted.org
+      >
+      > This issue **should NOT** be for any non-PyPI properties (like
+      > python.org, docs.python.org, etc.)
+
+      *Please fill out the form below with as many precise
+      details as possible.*
+
+      [issue search]: /pypi/support/search?q=is%3Aissue&type=issues
+      [Python Infrastructure Status Page]: https://status.python.org
 
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/access-issues.yml
+++ b/.github/ISSUE_TEMPLATE/access-issues.yml
@@ -11,7 +11,7 @@ body:
       > Before using this form to report a new issue, please verify that it has
       > not already been documented on the [Python Infrastructure Status Page].
       > Remember to scroll to the *Past Incidents* to see if there is something
-      > that's just been addressed too.
+      > that has recently been addressed.
       >
       > Verify first that your issue is not [already reported on GitHub][issue
       > search].

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,9 @@
 # Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
 blank_issues_enabled: false  # default is true
 contact_links:
+- name: Python Infrastructure Status Page
+  url: https://status.python.org
+  about: Please check this page, prior to reporting possible PyPI outages
 - name: Organizations Feature Support
   url: https://docs.pypi.org/organization-accounts/support/#organization-features
   about: For support related to using Organizations Features on PyPI


### PR DESCRIPTION
This patch seeks to make it more obvious to users that come to report PyPI infra problems that the Python Infra Status Page [[1]] is a thing, empowering them to figure out if something's being worked on already, reducing duplication/noise on this issue tracker.

[1]: https://status.python.org